### PR TITLE
OP-10184 New Relic mobile agent needs to be updated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.newrelic.agent.android:android-agent:5.11.+'
+    compile 'com.newrelic.agent.android:android-agent:5.20.0'
     compile 'com.facebook.react:react-native:+' //from node_modules
 }
+y

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lotto-nz/react-native-newrelic",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "New Relic wrapper for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
update the newrelic android-agent version to 5.20.0 and incremented the version to 1.1.3